### PR TITLE
modify db tests to pass

### DIFF
--- a/db/tests/action.sql
+++ b/db/tests/action.sql
@@ -3,18 +3,36 @@ BEGIN;
 SET search_path = tap, public;
 SELECT plan(13);
 
+INSERT INTO swoop.payload_cache (
+  payload_uuid,
+  payload_hash,
+  workflow_version,
+  workflow_name,
+  created_at,
+  invalid_after
+) VALUES (
+  'cdc73916-500c-4501-a658-dd706a943d19'::uuid,
+  decode('123\000456', 'escape'),
+  1,
+  'workflow-a',
+  '2023-04-14 00:25:07.388012+00'::timestamptz,
+  '2023-04-20 00:25:07.388012+00'::timestamptz
+);
+
 INSERT INTO swoop.action (
   action_uuid,
   action_type,
   handler_name,
   action_name,
-  created_at
+  created_at,
+  payload_uuid
 ) VALUES (
   'b15120b8-b7ab-4180-9b7a-b0384758f468'::uuid,
   'workflow',
   'argo-workflow',
   'workflow-a',
-  '2023-04-13 00:25:07.388012+00'::timestamptz
+  '2023-04-13 00:25:07.388012+00'::timestamptz,
+  'cdc73916-500c-4501-a658-dd706a943d19'::uuid
 );
 
 -- check event created as expected

--- a/db/tests/limit-locking.sql
+++ b/db/tests/limit-locking.sql
@@ -3,6 +3,22 @@ BEGIN;
 SET search_path = tap, public;
 SELECT plan(3);
 
+INSERT INTO swoop.payload_cache (
+  payload_uuid,
+  payload_hash,
+  workflow_version,
+  workflow_name,
+  created_at,
+  invalid_after
+) VALUES (
+  'cdc73916-500c-4501-a658-dd706a943d19'::uuid,
+  decode('123\000456', 'escape'),
+  1,
+  'workflow-a',
+  '2023-04-14 00:25:07.388012+00'::timestamptz,
+  '2023-04-20 00:25:07.388012+00'::timestamptz
+);
+
 DO
 $$
 BEGIN
@@ -12,13 +28,15 @@ BEGIN
       action_type,
       handler_name,
       action_name,
-      created_at
+      created_at,
+      payload_uuid
     ) VALUES (
       gen_random_uuid(),
       'workflow',
       'argo-workflow',
       'workflow-a',
-      now()
+      now(),
+      'cdc73916-500c-4501-a658-dd706a943d19'::uuid
     );
   END LOOP;
 END;
@@ -50,7 +68,7 @@ SELECT
   is(
     count(*),
     10::bigint,
-    'should have exepcted number of locks on threads'
+    'should have expected number of locks on threads'
   )
 FROM
   pg_locks


### PR DESCRIPTION
The tests inside the `db/tests` folder were not passing because we added in the `payload_uuid` field into the `swoop.action` table in the payload cache configuration PR and that field was getting set to null by default, which violated the `workflow_or_callback` constraint that we had modified as a part of the previous PR.

This modifies the `action.sql` and `limit-locking.sql` files in that it creates a sample entry in the `swoop.payload_cache` table which is being referenced by the `payload_uuid` field in the `swoop.action` table where the same value is inserted.