### PR TITLE
return inputs in GET /jobs/<job_id>/inputs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       SWOOP_SECRET_ACCESS_KEY: "${SWOOP_SECRET_ACCESS_KEY:-password}"
       SWOOP_S3_ENDPOINT: "http://minio:9000"
       SWOOP_BUCKET_NAME: "${SWOOP_BUCKET_NAME:-swoop}"
-      SWOOP_EXECUTION_DIR: "${SWOOP_EXECUTION_DIR:-s3://swoop/execution}"
+      SWOOP_EXECUTION_DIR: "${SWOOP_EXECUTION_DIR:-s3://swoop/executions}"
       SWOOP_WORKFLOW_CONFIG_FILE: "${SWOOP_WORKFLOW_CONFIG_FILE:-workflow-config.yml}"
       PGDATABASE: "${PGDATABASE:-swoop}"
       PGHOST: "postgres"

--- a/src/swoop/api/models/jobs.py
+++ b/src/swoop/api/models/jobs.py
@@ -143,3 +143,8 @@ class StatusInfo(BaseModel):
 class JobList(BaseModel):
     jobs: list[StatusInfo]
     links: list[Link]
+
+
+class WorkflowExecutionInput(BaseModel):
+    inputs: dict
+    links: list[Link]

--- a/src/swoop/api/routers/jobs.py
+++ b/src/swoop/api/routers/jobs.py
@@ -12,6 +12,7 @@ from swoop.api.models.jobs import (
     StatusCode,
     StatusInfo,
     SwoopStatusCode,
+    WorkflowExecutionInput,
     status_dict,
 )
 from swoop.api.models.shared import APIException, Link, Results
@@ -316,9 +317,15 @@ async def get_workflow_execution_inputs(request: Request, jobID) -> dict | APIEx
             status_code=404, detail="Workflow execution input payload not found"
         )
 
-    inputs = {"payload": payload}
+    links = [
+        Link.root_link(request),
+        Link.self_link(href=str(request.url)),
+    ]
 
-    return inputs
+    return WorkflowExecutionInput(
+        inputs={"payload": payload},
+        links=links,
+    )
 
 
 # @router.post(

--- a/src/swoop/api/routers/jobs.py
+++ b/src/swoop/api/routers/jobs.py
@@ -316,7 +316,9 @@ async def get_workflow_execution_inputs(request: Request, jobID) -> dict | APIEx
             status_code=404, detail="Workflow execution input payload not found"
         )
 
-    return payload
+    inputs = {"payload": payload}
+
+    return inputs
 
 
 # @router.post(

--- a/src/swoop/api/routers/jobs.py
+++ b/src/swoop/api/routers/jobs.py
@@ -287,7 +287,7 @@ async def get_workflow_execution_result(
     """
     Retrieves workflow execution output payload by jobID
     """
-    results = request.app.state.io.get_object(f"/execution/{jobID}/output.json")
+    results = request.app.state.io.get_object(f"/executions/{jobID}/output.json")
 
     if not results:
         raise HTTPException(
@@ -309,7 +309,7 @@ async def get_workflow_execution_inputs(request: Request, jobID) -> dict | APIEx
     """
     Retrieves workflow execution input payload by jobID
     """
-    payload = request.app.state.io.get_object(f"/execution/{jobID}/input.json")
+    payload = request.app.state.io.get_object(f"/executions/{jobID}/input.json")
 
     if not payload:
         raise HTTPException(

--- a/tests/api/test_jobs.py
+++ b/tests/api/test_jobs.py
@@ -442,8 +442,10 @@ async def test_get_job_payload(test_client: TestClient):
     )
     assert response.status_code == 200
     assert response.json() == {
-        "process_id": "0187c88d-a9e0-788c-adcb-c0b951f8be91",
-        "payload": "test_input",
+        "payload": {
+            "process_id": "0187c88d-a9e0-788c-adcb-c0b951f8be91",
+            "payload": "test_input",
+        }
     }
 
 

--- a/tests/api/test_jobs.py
+++ b/tests/api/test_jobs.py
@@ -441,11 +441,22 @@ async def test_get_job_payload(test_client: TestClient):
         "/jobs/0187c88d-a9e0-788c-adcb-c0b951f8be91/inputs",
     )
     assert response.status_code == 200
+
     assert response.json() == {
-        "payload": {
-            "process_id": "0187c88d-a9e0-788c-adcb-c0b951f8be91",
-            "payload": "test_input",
-        }
+        "inputs": {
+            "payload": {
+                "process_id": "0187c88d-a9e0-788c-adcb-c0b951f8be91",
+                "payload": "test_input",
+            }
+        },
+        "links": [
+            {"href": "http://testserver/", "rel": "root", "type": "application/json"},
+            {
+                "href": "http://testserver/jobs/0187c88d-a9e0-788c-adcb-c0b951f8be91/inputs",
+                "rel": "self",
+                "type": "application/json",
+            },
+        ],
     }
 
 

--- a/tests/api/test_jobs.py
+++ b/tests/api/test_jobs.py
@@ -8,11 +8,11 @@ inject_io_fixture(
     [
         {
             "source": "base_01",
-            "destination": "/execution/0187c88d-a9e0-788c-adcb-c0b951f8be91",
+            "destination": "/executions/0187c88d-a9e0-788c-adcb-c0b951f8be91",
         },
         {
             "source": "base_02",
-            "destination": "/execution/0187c88d-a9e0-757e-aa36-2fbb6c834cb5",
+            "destination": "/executions/0187c88d-a9e0-757e-aa36-2fbb6c834cb5",
         },
     ],
     __name__,
@@ -441,7 +441,6 @@ async def test_get_job_payload(test_client: TestClient):
         "/jobs/0187c88d-a9e0-788c-adcb-c0b951f8be91/inputs",
     )
     assert response.status_code == 200
-    print(response.json())
     assert response.json() == {
         "process_id": "0187c88d-a9e0-788c-adcb-c0b951f8be91",
         "payload": "test_input",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -136,11 +136,11 @@ inject_io_fixture(
     [
         {
             "source": "base_01",
-            "destination": "/execution/2595f2da-81a6-423c-84db-935e6791046e",
+            "destination": "/executions/2595f2da-81a6-423c-84db-935e6791046e",
         },
         {
             "source": "base_02",
-            "destination": "/execution/81842304-0aa9-4609-89f0-1c86819b0752",
+            "destination": "/executions/81842304-0aa9-4609-89f0-1c86819b0752",
         },
     ],
     __name__,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -8,11 +8,11 @@ inject_io_fixture(
     [
         {
             "source": "base_01",
-            "destination": "/execution/2595f2da-81a6-423c-84db-935e6791046e",
+            "destination": "/executions/2595f2da-81a6-423c-84db-935e6791046e",
         },
         {
             "source": "base_02",
-            "destination": "/execution/81842304-0aa9-4609-89f0-1c86819b0752",
+            "destination": "/executions/81842304-0aa9-4609-89f0-1c86819b0752",
         },
     ],
     __name__,
@@ -30,7 +30,7 @@ def test_hasbucket(test_client, bucket_name):
 
 def test_add_object(test_client, single_object):
     test_client.app.state.io.put_object(
-        "/execution/2595f2da-81a6-423c-84db-935e6791046e/io.json",
+        "/executions/2595f2da-81a6-423c-84db-935e6791046e/io.json",
         json.dumps(single_object),
     )
     assert True
@@ -38,6 +38,6 @@ def test_add_object(test_client, single_object):
 
 def test_remove_object(test_client):
     test_client.app.state.io.delete_object(
-        "/execution/2595f2da-81a6-423c-84db-935e6791046e/io.json"
+        "/executions/2595f2da-81a6-423c-84db-935e6791046e/io.json"
     )
     assert True


### PR DESCRIPTION
return the same thing that the user provided as inputs in the /processes/<processID>/execution request that triggered the job for `GET /jobs/<job_id>/inputs` endpoint
